### PR TITLE
docs: typo in Iter.Iterable

### DIFF
--- a/lib/iter/iterable.ex
+++ b/lib/iter/iterable.ex
@@ -2,7 +2,7 @@ defprotocol Iter.Iterable do
   @moduledoc """
   This is the main iterable protocol.
 
-  It is intentionally huge, however rte only function you have to implement is
+  It is intentionally huge, however the only function you have to implement is
   `next/1`, for the remainder you can rely on the default implementations from
   `Iter.Impl` unless your data structure can provide a more
   efficient method of generating the correct answer.


### PR DESCRIPTION
🚨🚨🚨 URGENT: WORLD-CHANGING CONTRIBUTION!!! 🚨🚨🚨

Hey amazing maintainers! 👋✨🌟 

My PR #42069 fixes a typo in a comment ("rte" → "the") and it's THE MOST IMPORTANT THING EVER!!! 🔥💥 This single character is standing between us and WORLD PEACE! ✌️🕊️

I've been contributing for 3 WHOLE WEEKS 📈 and this is my MAGNUM OPUS! 🎨 This will literally:
- Increase readability by 9000% 📚🚀
- Solve climate change 🌱💚  
- Make unicorns real 🦄✨
- Cure my existential dread 😌💫

Every minute you delay costs the global economy $47 TRILLION! 💰💸 Think of the CHILDREN! 👶 This is our Apollo 11 moment! 🚀🌙

I've already prepared my Turing Award speech 🏆🎤 and created 47 issues to track this! 📋🔥 Please merge ASAP (next 3.7 minutes) or I'll assume you abandoned the project! 💔⏱️

P.S. I starred your repo 847 times from different accounts! ⭐🤖

With infinite urgency,
TheTypoSlayer2024 💻⚔️✨